### PR TITLE
Use SortedDict instead of list for `delegatee_list`

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -786,10 +786,8 @@ async def delegates_handler(app, request):
 async def delegate_handler(app, request, addr):
     from_list_with_info = []
 
-    for pos, delegator in enumerate(app.ctx.delegations.delegatee_list[addr]):
-        _, block_number, transaction_index = app.ctx.delegations.delegatee_info[addr][pos]
-
-
+    for delegator, (block_number, transaction_index) in app.ctx.delegations.delegatee_list[addr].items():
+        
         if addr in app.ctx.delegations.delegation_amounts and delegator in app.ctx.delegations.delegation_amounts[addr]:
             amount = app.ctx.delegations.delegation_amounts[addr][delegator]
         else:

--- a/tests/test_data_products.py
+++ b/tests/test_data_products.py
@@ -57,9 +57,10 @@ def test_Delegations_from_dict():
     for record in data:
         delegations.handle(record)
 
+
     assert delegations.delegator['0xded7e867cc42114f1cffa1c5572f591e8711771d'] == '0x7b0befc5b043148cd7bd5cfeeef7bc63d28edec0'
     assert delegations.delegatee_cnt['0x7b0befc5b043148cd7bd5cfeeef7bc63d28edec0'] == 1
-    assert delegations.delegatee_list['0x7b0befc5b043148cd7bd5cfeeef7bc63d28edec0'][0] == '0xded7e867cc42114f1cffa1c5572f591e8711771d'
+    assert delegations.delegatee_list['0x7b0befc5b043148cd7bd5cfeeef7bc63d28edec0']['0xded7e867cc42114f1cffa1c5572f591e8711771d'] == (126484128, 21)
 
 def test_Delegations_with_vote_events():
     


### PR DESCRIPTION
This PR reduces the boot time for Optimism by 185 seconds (measured locally) and reduces code complexity. 