### PR TITLE
Paginated Logs recursive function

### DIFF
--- a/app/clients.py
+++ b/app/clients.py
@@ -1,3 +1,4 @@
+import logging
 from warnings import warn
 from pathlib import Path
 import csv
@@ -229,7 +230,7 @@ class JsonRpcHistHttpClient:
             logr.info(f"No block older than {days_back} days found.")
             return 0
 
-    def get_paginated_logs(self, w3, contract_address, event_signature_hash, start_block, end_block, step, abi):
+    def get_paginated_logs(self, w3, contract_address, event_signature_hash, start_block, end_block, step, abi, max_recursion_depth=10):
 
         all_logs = []
 
@@ -245,9 +246,9 @@ class JsonRpcHistHttpClient:
 
             # Fetch the logs for the current block range
             try:
-                logs = self.get_logs_by_block_range(w3, contract_address, event_signature_hash, from_block, to_block)
+                logs = self.get_logs_by_block_range(w3, contract_address, event_signature_hash, from_block, to_block, max_recursion_depth=max_recursion_depth)
             except Exception as e:
-                print(f"Failed to get logs {e}")
+                logging.error(f"Failed to get logs {e}")
                 raise e
 
             EVENT_NAME = abi['name']            

--- a/app/clients.py
+++ b/app/clients.py
@@ -265,6 +265,23 @@ class JsonRpcHistHttpClient:
         return all_logs
 
     def get_logs_by_block_range(self, w3, contract_address, event_signature_hash, from_block, to_block, current_recursion_depth = 0, max_recursion_depth=10):
+        """
+This is a recursive function that will split itself apart to handle block ranges that exceed the block limit of the external API.
+
+It is unlikely that this function will ever be called directly, and is instead called by
+    the :py:meth:`~.clients.JsonRpcHistHttpClient.get_paginated_logs` function, where additional
+    processing is performed.
+
+:param w3: The web3 object used to interact with the external API.
+:param contract_address: The address of the contract to which the event is emitted.
+:param event_signature_hash: The hash of the event signature.
+:param from_block: The starting block number for the block range.
+:param to_block: The ending block number for the block range.
+:param current_recursion_depth: The current recursion depth of the function. Used for tracking recursion depth.
+:param max_recursion_depth: The maximum recursion depth allowed for the function. If the recursion depth exceeds this value, an exception will be raised. This prevents infinite recursion.
+:returns: A list of logs from the specified block range.
+           """
+
         # Set filter parameters for each range
         event_filter = {
             "fromBlock": from_block,

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -87,7 +87,7 @@ optimism_package = {
     "event_signature": "VoteCast(address,uint256,uint8,uint256,string)",
 }
 
-@pytest.mark.skip(reason="This test is runs an API Call")
+# @pytest.mark.skip(reason="This test is runs an API Call")
 @pytest.mark.parametrize("test_package", [optimism_package])
 def test_get_paginated_logs(test_package):
     print("\n")
@@ -119,7 +119,7 @@ def test_get_paginated_logs(test_package):
         proposal_id = log['args']['proposalId']
         assert proposal_id== 105196850607896626370893604768027381433548036180811365072963268567142002370039
 
-@pytest.mark.skip(reason="This test is runs an API Call")
+# @pytest.mark.skip(reason="This test is runs an API Call")
 @pytest.mark.parametrize("test_package", [optimism_package])
 def test_get_paginated_logs_block_range_over_2000(test_package):
     print("\n")
@@ -127,9 +127,6 @@ def test_get_paginated_logs_block_range_over_2000(test_package):
 
     # Use correct Transfer event signature
     hash_of_event_sig = '0x' + keccak(test_package['event_signature'].encode()).hex()
-
-    # Test connection first
-    w3 = jrhhc.connect()
 
     # Define block range for Optimism token events
     start_block = 135252530
@@ -150,5 +147,5 @@ def test_get_paginated_logs_block_range_over_2000(test_package):
     )
 
     print(f"Found {len(logs)} CastVote events")
-
+    assert len(logs) == 87
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -116,6 +116,7 @@ def test_get_paginated_logs(test_package):
 
     print(f"Found {len(logs)} CastVote events")
     for log in logs:
+        # Should return the same proposal
         proposal_id = log['args']['proposalId']
         assert proposal_id== 105196850607896626370893604768027381433548036180811365072963268567142002370039
 
@@ -148,4 +149,58 @@ def test_get_paginated_logs_block_range_over_2000(test_package):
 
     print(f"Found {len(logs)} CastVote events")
     assert len(logs) == 87
+
+# @pytest.mark.skip(reason="This test is runs an API Call")
+@pytest.mark.parametrize("test_package", [optimism_package])
+def test_get_paginated_logs_are_in_chronological_order(test_package):
+    print("\n")
+    jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
+
+    # Use correct Transfer event signature
+    hash_of_event_sig = '0x' + keccak(test_package['event_signature'].encode()).hex()
+
+    # Define block range for Optimism token events
+    start_block = 135252530
+    end_block = 135262530
+
+
+    block_count_span = resolve_block_count_span(10)
+
+    # Query transfer logs from Optimism token contract
+    logs = jrhhc.get_paginated_logs(
+        jrhhc.connect(),
+        test_package['gov_contract_address'],
+        hash_of_event_sig,
+        start_block,
+        end_block,
+        block_count_span,
+        test_package['vote_cast_abi'],
+    )
+
+    curr_high_bn = start_block
+    curr_high_tran_idx = 0
+    curr_high_log_idx = 0
+    for log in logs:
+        current_block_number = log['blockNumber']
+        # blockNumber should always be ascending
+        assert current_block_number >= curr_high_bn
+        if current_block_number == curr_high_bn:
+            current_tran_idx = log['transactionIndex']
+            # If the same blockNumber, transactionIndex should be ascending
+            assert current_tran_idx >= curr_high_tran_idx
+            if current_tran_idx == curr_high_tran_idx:
+                current_log_idx = log['logIndex']
+                # If the same transactionIndex, logIndex should be ascending
+                assert current_log_idx > curr_high_log_idx
+                curr_high_log_idx = current_log_idx
+
+        # Set the new highs
+        # Reset to 0 if assert and if statements pass.
+        # -1 Allows the index to be 0
+            else:
+                curr_high_tran_idx = current_tran_idx
+                curr_high_log_idx = -1
+        else:
+            curr_high_bn = current_block_number
+            curr_high_tran_idx = -1
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,8 +1,12 @@
+import os
+import json
+
 import pytest
 from app.utils import camel_to_snake
 from app.signatures import DELEGATE_VOTES_CHANGE, DELEGATE_CHANGED_1
 from eth_abi.abi import decode as decode_abi
-from app.clients import JsonRpcRTWsClient
+from app.clients import JsonRpcRTWsClient, JsonRpcHistHttpClient, resolve_block_count_span
+from dotenv import load_dotenv
 
 delegate_changed_ws_payload = {'address': '0x27b0031c64f4231f0aff28e668553d73f48125f3', 'topics': ['0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f', '0x000000000000000000000000c950b9f32259860f4731d318cb5a28b2db892f88', '0x000000000000000000000000c950b9f32259860f4731d318cb5a28b2db892f88', '0x0000000000000000000000000000000000000000000000000000000000000000'], 'data': '0x', 'blockNumber': '0x7ce8d9', 'transactionHash': '0x6ee9de9644f6c75d83d598240067d1f20466b10c8721a61a8870a040efbafad8', 'transactionIndex': '0x1f', 'blockHash': '0x81f0810aa58f1f30ac28e10aa9680c9b4247fc38a8b6a273f847f1fc06c92365', 'logIndex': '0x32', 'removed': False}
 delegate_votes_changed_ws_payload = {'address': '0x27b0031c64f4231f0aff28e668553d73f48125f3', 'topics': ['0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724', '0x000000000000000000000000c950b9f32259860f4731d318cb5a28b2db892f88'], 'data': '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000', 'blockNumber': '0x7ce8d9', 'transactionHash': '0x6ee9de9644f6c75d83d598240067d1f20466b10c8721a61a8870a040efbafad8', 'transactionIndex': '0x1f', 'blockHash': '0x81f0810aa58f1f30ac28e10aa9680c9b4247fc38a8b6a273f847f1fc06c92365', 'logIndex': '0x33', 'removed': False}
@@ -30,3 +34,29 @@ def test_web_socket_response_serialization(pguild_token_abi, ws_payload, signatu
     out = JsonRpcRTWsClient.decode_payload(ws_payload, inputs, signature, topic)
 
     assert out == expected_event
+
+def test_get_paginated_logs():
+    load_dotenv()
+    DAO_NODE_ARCHIVE_NODE_HTTP = "https://opbnb-mainnet.g.alchemy.com/v2/"
+    ARCHIVE_NODE_HTTP_URL = DAO_NODE_ARCHIVE_NODE_HTTP + os.getenv('ALCHEMY_API_KEY', '')
+    jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
+
+    block_count_span = resolve_block_count_span(10)
+
+    with open('./abis/op-gov.json', 'r') as f:
+        abi = json.load(f)
+
+    logs = jrhhc.get_paginated_logs(
+        jrhhc.connect(),
+        "0x27b0031c64f4231f0aff28e668553d73f48125f3",
+        "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f",
+        1000000000000000000000000000000000000000000000000000000000000000,
+        1000000000000000000000000000000000000000000000000000000000000000,
+        block_count_span,
+        abi
+    )
+
+    print(logs)
+
+def test_get_paginated_logs_block_range_over_2000():
+    pass

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -87,13 +87,15 @@ optimism_package = {
     "event_signature": "VoteCast(address,uint256,uint8,uint256,string)",
 }
 
-def test_get_paginated_logs():
+@pytest.mark.skip(reason="This test is runs an API Call")
+@pytest.mark.parametrize("test_package", [optimism_package])
+def test_get_paginated_logs(test_package):
     print("\n")
 
     jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
 
     # Use the correct Transfer event signature
-    hash_of_event_sig = '0x' + keccak(optimism_package['event_signature'].encode()).hex()
+    hash_of_event_sig = '0x' + keccak(test_package['event_signature'].encode()).hex()
 
     # Define block range for Optimism token events
     start_block = 135262515
@@ -104,12 +106,12 @@ def test_get_paginated_logs():
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
         jrhhc.connect(),
-        optimism_package['gov_contract_address'],
+        test_package['gov_contract_address'],
         hash_of_event_sig,
         start_block,
         end_block,
         block_count_span,
-        optimism_package['vote_cast_abi'],
+        test_package['vote_cast_abi'],
     )
 
     print(f"Found {len(logs)} CastVote events")
@@ -117,12 +119,14 @@ def test_get_paginated_logs():
         proposal_id = log['args']['proposalId']
         assert proposal_id== 105196850607896626370893604768027381433548036180811365072963268567142002370039
 
-def test_get_paginated_logs_block_range_over_2000():
+@pytest.mark.skip(reason="This test is runs an API Call")
+@pytest.mark.parametrize("test_package", [optimism_package])
+def test_get_paginated_logs_block_range_over_2000(test_package):
     print("\n")
     jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
 
     # Use correct Transfer event signature
-    hash_of_event_sig = '0x' + keccak(optimism_package['event_signature'].encode()).hex()
+    hash_of_event_sig = '0x' + keccak(test_package['event_signature'].encode()).hex()
 
     # Test connection first
     w3 = jrhhc.connect()
@@ -137,12 +141,12 @@ def test_get_paginated_logs_block_range_over_2000():
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
         jrhhc.connect(),
-        optimism_package['gov_contract_address'],
+        test_package['gov_contract_address'],
         hash_of_event_sig,
         start_block,
         end_block,
         block_count_span,
-        optimism_package['vote_cast_abi'],
+        test_package['vote_cast_abi'],
     )
 
     print(f"Found {len(logs)} CastVote events")

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -39,6 +39,8 @@ def test_web_socket_response_serialization(pguild_token_abi, ws_payload, signatu
     assert out == expected_event
 
 
+mock_logs = [{x: f"Test Log {x}" for x in range(100)}]
+
 def test_get_paginated_logs():
     print("\n")
     load_dotenv()
@@ -199,81 +201,4 @@ def test_get_paginated_logs_block_range_over_2000():
 
     print(f"Found {len(logs)} CastVote events")
 
-mock_logs = [{x: f"Test Log {x}" for x in range(100)}]
 
-def mock_get_logs(event_filter):
-    start = event_filter.get('fromBlock')
-    end = event_filter.get('toBlock')
-
-    if end - start > 20:
-        raise Exception(
-            "web3.exceptions.Web3RPCError: {'code': -32602, 'message': 'Log response size exceeded. You can make eth_getLogs requests with up to a 2K block range and no limit on the response size, or you can request any block range with a cap of 10K logs in the response. Based on your parameters and the response size limit, this block range should work: [0x81c5fbc, 0x81c6902]'}")
-
-    return [log for x, log in enumerate(mock_logs) if start <= x <= end]
-
-def poc(from_block, to_block, contract_address, event_signature_hash, current_recursion_depth, max_recursion_depth=10):
-    if current_recursion_depth > max_recursion_depth:
-        raise Exception(f"Maximum recursion depth {max_recursion_depth} exceeded. This can be adjusted in the function parameter.")
-
-    event_filter = {
-        "fromBlock": from_block,
-        "toBlock": to_block,
-        "address": contract_address,
-        "topics": [event_signature_hash]
-    }
-    try:
-        logs = mock_get_logs(event_filter)
-        return logs
-    except Exception as e:
-        error_msg = str(e)
-        if "Log response size exceeded" in error_msg:
-            print("Recursively calling poc with a smaller block range.")
-
-            # add one to recursion depth
-            current_recursion_depth += 1
-
-            # split block range in half
-            mid = (from_block + to_block) // 2
-
-            print(f"poc1: from {from_block} - {mid-1}\npoc2: from {mid} - {to_block}")
-            # Get results from both recursive calls
-            first_half = poc(
-                from_block=from_block,
-                to_block=mid - 1,
-                contract_address=contract_address,
-                event_signature_hash=event_signature_hash,
-                current_recursion_depth=current_recursion_depth,
-                max_recursion_depth=max_recursion_depth
-            )
-
-            second_half = poc(
-                from_block=mid,
-                to_block=to_block,
-                contract_address=contract_address,
-                event_signature_hash=event_signature_hash,
-                current_recursion_depth=current_recursion_depth,
-                max_recursion_depth=max_recursion_depth
-            )
-
-            # Combine results, handling potential None values
-            result = []
-            if first_half is not None:
-                result.extend(first_half)
-            if second_half is not None:
-                result.extend(second_half)
-            return result
-
-        else:
-                raise e
-
-
-def test_poc():
-    logs = poc(
-        from_block=0,
-        to_block=100,
-        contract_address="0x27b0031c64f4231f0aff28e668553d73f48125f3",
-        event_signature_hash="0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f",
-        current_recursion_depth=0,
-        max_recursion_depth=10
-    )
-    print(logs)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -39,37 +39,15 @@ def test_web_socket_response_serialization(pguild_token_abi, ws_payload, signatu
     assert out == expected_event
 
 
+load_dotenv()
+DAO_NODE_ARCHIVE_NODE_HTTP = "https://opt-mainnet.g.alchemy.com/v2/"
+ARCHIVE_NODE_HTTP_URL = DAO_NODE_ARCHIVE_NODE_HTTP + os.getenv('ALCHEMY_API_KEY', '')
+
 mock_logs = [{x: f"Test Log {x}" for x in range(100)}]
 
-def test_get_paginated_logs():
-    print("\n")
-    load_dotenv()
-    DAO_NODE_ARCHIVE_NODE_HTTP = "https://opt-mainnet.g.alchemy.com/v2/"
-    ARCHIVE_NODE_HTTP_URL = DAO_NODE_ARCHIVE_NODE_HTTP + os.getenv('ALCHEMY_API_KEY', '')
-    jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
-
-    # Use correct Transfer event signature
-    event_sig = "VoteCast(address,uint256,uint8,uint256,string)"
-    hash_of_event_sig = '0x' + keccak(event_sig.encode()).hex()
-
-    # Test connection first
-    w3 = jrhhc.connect()
-    print(f"Connected to network. Chain ID: {w3.eth.chain_id}")
-    print(f"Current block: {w3.eth.block_number}")
-
-    # Define block range for Optimism token events
-    start_block = 135262515
-    end_block = 135262530
-    print(f"Scanning blocks {start_block} to {end_block}")
-
-
-
-    optimisim_gov_contract_address = "0xcDF27F107725988f2261Ce2256bDfCdE8B382B10"
-
-    block_count_span = resolve_block_count_span(10)
-
-    # Load Optimism Gov VoteCast ABI
-    abi = {
+optimism_package = {
+    "gov_contract_address": "0xcDF27F107725988f2261Ce2256bDfCdE8B382B10",
+    "vote_cast_abi": {
         "type": "event",
         "name": "VoteCast",
         "inputs": [
@@ -105,18 +83,33 @@ def test_get_paginated_logs():
             }
         ],
         "anonymous": False
-    }
+    },
+    "event_signature": "VoteCast(address,uint256,uint8,uint256,string)",
+}
 
+def test_get_paginated_logs():
+    print("\n")
+
+    jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
+
+    # Use the correct Transfer event signature
+    hash_of_event_sig = '0x' + keccak(optimism_package['event_signature'].encode()).hex()
+
+    # Define block range for Optimism token events
+    start_block = 135262515
+    end_block = 135262530
+
+    block_count_span = resolve_block_count_span(10)
 
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
         jrhhc.connect(),
-        optimisim_gov_contract_address,
+        optimism_package['gov_contract_address'],
         hash_of_event_sig,
         start_block,
         end_block,
         block_count_span,
-        abi
+        optimism_package['vote_cast_abi'],
     )
 
     print(f"Found {len(logs)} CastVote events")
@@ -126,77 +119,30 @@ def test_get_paginated_logs():
 
 def test_get_paginated_logs_block_range_over_2000():
     print("\n")
-    load_dotenv()
-    DAO_NODE_ARCHIVE_NODE_HTTP = "https://opt-mainnet.g.alchemy.com/v2/"
-    ARCHIVE_NODE_HTTP_URL = DAO_NODE_ARCHIVE_NODE_HTTP + os.getenv('ALCHEMY_API_KEY', '')
     jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
 
     # Use correct Transfer event signature
-    event_sig = "VoteCast(address,uint256,uint8,uint256,string)"
-    hash_of_event_sig = '0x' + keccak(event_sig.encode()).hex()
+    hash_of_event_sig = '0x' + keccak(optimism_package['event_signature'].encode()).hex()
 
     # Test connection first
     w3 = jrhhc.connect()
-    print(f"Connected to network. Chain ID: {w3.eth.chain_id}")
-    print(f"Current block: {w3.eth.block_number}")
 
     # Define block range for Optimism token events
     start_block = 135252530
     end_block = 135262530
-    print(f"Scanning blocks {start_block} to {end_block}")
 
-    optimisim_gov_contract_address = "0xcDF27F107725988f2261Ce2256bDfCdE8B382B10"
 
     block_count_span = resolve_block_count_span(10)
-
-    # Load Optimism Gov VoteCast ABI
-    abi = {
-        "type": "event",
-        "name": "VoteCast",
-        "inputs": [
-            {
-                "name": "voter",
-                "type": "address",
-                "indexed": True,
-                "internalType": "address"
-            },
-            {
-                "name": "proposalId",
-                "type": "uint256",
-                "indexed": False,
-                "internalType": "uint256"
-            },
-            {
-                "name": "support",
-                "type": "uint8",
-                "indexed": False,
-                "internalType": "uint8"
-            },
-            {
-                "name": "weight",
-                "type": "uint256",
-                "indexed": False,
-                "internalType": "uint256"
-            },
-            {
-                "name": "reason",
-                "type": "string",
-                "indexed": False,
-                "internalType": "string"
-            }
-        ],
-        "anonymous": False
-    }
 
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
         jrhhc.connect(),
-        optimisim_gov_contract_address,
+        optimism_package['gov_contract_address'],
         hash_of_event_sig,
         start_block,
         end_block,
         block_count_span,
-        abi
+        optimism_package['vote_cast_abi'],
     )
 
     print(f"Found {len(logs)} CastVote events")

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 from _pytest.outcomes import Exit
+from eth_utils import keccak
 
 from app.utils import camel_to_snake
 from app.signatures import DELEGATE_VOTES_CHANGE, DELEGATE_CHANGED_1
@@ -37,31 +38,166 @@ def test_web_socket_response_serialization(pguild_token_abi, ws_payload, signatu
 
     assert out == expected_event
 
+
 def test_get_paginated_logs():
+    print("\n")
     load_dotenv()
-    DAO_NODE_ARCHIVE_NODE_HTTP = "https://opbnb-mainnet.g.alchemy.com/v2/"
+    DAO_NODE_ARCHIVE_NODE_HTTP = "https://opt-mainnet.g.alchemy.com/v2/"
     ARCHIVE_NODE_HTTP_URL = DAO_NODE_ARCHIVE_NODE_HTTP + os.getenv('ALCHEMY_API_KEY', '')
     jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
 
+    # Use correct Transfer event signature
+    event_sig = "VoteCast(address,uint256,uint8,uint256,string)"
+    hash_of_event_sig = '0x' + keccak(event_sig.encode()).hex()
+
+    # Test connection first
+    w3 = jrhhc.connect()
+    print(f"Connected to network. Chain ID: {w3.eth.chain_id}")
+    print(f"Current block: {w3.eth.block_number}")
+
+    # Define block range for Optimism token events
+    start_block = 135262515
+    end_block = 135262530
+    print(f"Scanning blocks {start_block} to {end_block}")
+
+
+
+    optimisim_gov_contract_address = "0xcDF27F107725988f2261Ce2256bDfCdE8B382B10"
+
     block_count_span = resolve_block_count_span(10)
 
-    with open('./abis/op-gov.json', 'r') as f:
-        abi = json.load(f)
+    # Load Optimism Gov VoteCast ABI
+    abi = {
+        "type": "event",
+        "name": "VoteCast",
+        "inputs": [
+            {
+                "name": "voter",
+                "type": "address",
+                "indexed": True,
+                "internalType": "address"
+            },
+            {
+                "name": "proposalId",
+                "type": "uint256",
+                "indexed": False,
+                "internalType": "uint256"
+            },
+            {
+                "name": "support",
+                "type": "uint8",
+                "indexed": False,
+                "internalType": "uint8"
+            },
+            {
+                "name": "weight",
+                "type": "uint256",
+                "indexed": False,
+                "internalType": "uint256"
+            },
+            {
+                "name": "reason",
+                "type": "string",
+                "indexed": False,
+                "internalType": "string"
+            }
+        ],
+        "anonymous": False
+    }
 
+
+    # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
         jrhhc.connect(),
-        "0x27b0031c64f4231f0aff28e668553d73f48125f3",
-        "0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f",
-        1000000000000000000000000000000000000000000000000000000000000000,
-        1000000000000000000000000000000000000000000000000000000000000000,
+        optimisim_gov_contract_address,
+        hash_of_event_sig,
+        start_block,
+        end_block,
         block_count_span,
         abi
     )
 
-    print(logs)
+    print(f"Found {len(logs)} CastVote events")
+    for log in logs:
+        proposal_id = log['args']['proposalId']
+        assert proposal_id== 105196850607896626370893604768027381433548036180811365072963268567142002370039
 
 def test_get_paginated_logs_block_range_over_2000():
-    pass
+    print("\n")
+    load_dotenv()
+    DAO_NODE_ARCHIVE_NODE_HTTP = "https://opt-mainnet.g.alchemy.com/v2/"
+    ARCHIVE_NODE_HTTP_URL = DAO_NODE_ARCHIVE_NODE_HTTP + os.getenv('ALCHEMY_API_KEY', '')
+    jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
+
+    # Use correct Transfer event signature
+    event_sig = "VoteCast(address,uint256,uint8,uint256,string)"
+    hash_of_event_sig = '0x' + keccak(event_sig.encode()).hex()
+
+    # Test connection first
+    w3 = jrhhc.connect()
+    print(f"Connected to network. Chain ID: {w3.eth.chain_id}")
+    print(f"Current block: {w3.eth.block_number}")
+
+    # Define block range for Optimism token events
+    start_block = 135252530
+    end_block = 135262530
+    print(f"Scanning blocks {start_block} to {end_block}")
+
+    optimisim_gov_contract_address = "0xcDF27F107725988f2261Ce2256bDfCdE8B382B10"
+
+    block_count_span = resolve_block_count_span(10)
+
+    # Load Optimism Gov VoteCast ABI
+    abi = {
+        "type": "event",
+        "name": "VoteCast",
+        "inputs": [
+            {
+                "name": "voter",
+                "type": "address",
+                "indexed": True,
+                "internalType": "address"
+            },
+            {
+                "name": "proposalId",
+                "type": "uint256",
+                "indexed": False,
+                "internalType": "uint256"
+            },
+            {
+                "name": "support",
+                "type": "uint8",
+                "indexed": False,
+                "internalType": "uint8"
+            },
+            {
+                "name": "weight",
+                "type": "uint256",
+                "indexed": False,
+                "internalType": "uint256"
+            },
+            {
+                "name": "reason",
+                "type": "string",
+                "indexed": False,
+                "internalType": "string"
+            }
+        ],
+        "anonymous": False
+    }
+
+    # Query transfer logs from Optimism token contract
+    logs = jrhhc.get_paginated_logs(
+        jrhhc.connect(),
+        optimisim_gov_contract_address,
+        hash_of_event_sig,
+        start_block,
+        end_block,
+        block_count_span,
+        abi
+    )
+
+    print(f"Found {len(logs)} CastVote events")
 
 mock_logs = [{x: f"Test Log {x}" for x in range(100)}]
 


### PR DESCRIPTION
```markdown
### Description of Changes
- Standard log still gets called in the same way
- If the blockrange is too large, it will automatically try to break it down into two equal parts recursively.
- Stitched logs return in a sequential manor.

- Seprated recursive function call out of get_paginated_logs.
  - You can now pass recursive depth limit to get_paginated_logs for customization
    
This is somewhat dependent on using Alchemy as the RPC. It would be worthwhile at some point in the future to break up the vendor specific logic so they are interoperable.    

``` 