### PR TITLE
Delegator param

### DIFF
--- a/app/data_products.py
+++ b/app/data_products.py
@@ -130,8 +130,6 @@ def round_and_seven_days_ago(ts):
 
 class Delegations(DataProduct):
     def __init__(self):
-        self.delegator = defaultdict(None) # owner, doing the delegation
-        
         # Data about the delegatee (ie, the delegate's influence)
         self.delegatee_list = defaultdict(SortedDict) #  list of delegators
         self.delegatee_cnt = defaultdict(int) #  dele
@@ -226,7 +224,6 @@ class Delegations(DataProduct):
             to_delegate = event['to_delegate'].lower()
             from_delegate = event['from_delegate'].lower()
 
-            self.delegator[delegator] = to_delegate
             self.delegatee_list[to_delegate][delegator] = (block_number, transaction_index)
 
             if to_delegate != '0x0000000000000000000000000000000000000000':

--- a/app/server.py
+++ b/app/server.py
@@ -741,11 +741,11 @@ async def delegates_handler(app, request):
     out = []
     if delegator_address_filter:
         delegator_address_filter_lower = delegator_address_filter.lower()
-        target_delegatee_addresses = app.ctx.delegations.delegator_delegate.get(delegator_address_filter_lower, set())
+        target_delegatee_addresses = app.ctx.delegations.delegator_delegate[delegator_address_filter_lower]
         
         if target_delegatee_addresses:
             for delegate_addr in target_delegatee_addresses:
-                delegate_addr_lower = delegate_addr.lower()
+                delegate_addr_lower = delegate_addr
                 sort_val = _get_delegate_sort_value(app.ctx, delegate_addr_lower, sort_by, pm if sort_by_pr else None)
                 
                 # Apply LVB specific pruning if sorting by LVB

--- a/tests/test_data_products.py
+++ b/tests/test_data_products.py
@@ -58,7 +58,7 @@ def test_Delegations_from_dict():
         delegations.handle(record)
 
 
-    assert delegations.delegator['0xded7e867cc42114f1cffa1c5572f591e8711771d'] == '0x7b0befc5b043148cd7bd5cfeeef7bc63d28edec0'
+    assert delegations.delegator_delegate['0xded7e867cc42114f1cffa1c5572f591e8711771d'] == {'0x7b0befc5b043148cd7bd5cfeeef7bc63d28edec0'}
     assert delegations.delegatee_cnt['0x7b0befc5b043148cd7bd5cfeeef7bc63d28edec0'] == 1
     assert delegations.delegatee_list['0x7b0befc5b043148cd7bd5cfeeef7bc63d28edec0']['0xded7e867cc42114f1cffa1c5572f591e8711771d'] == (126484128, 21)
 
@@ -74,7 +74,7 @@ def test_Delegations_with_vote_events():
     for event in delegation_events:
         delegations.handle(event)
 
-    assert delegations.delegator['0xded7e867cc42114f1cffa1c5572f591e8711771d'] == '0xded7e867cc42114f1cffa1c5572f591e8711771d'
+    assert delegations.delegator_delegate['0xded7e867cc42114f1cffa1c5572f591e8711771d'] == {'0xded7e867cc42114f1cffa1c5572f591e8711771d'}
     
     # Create a Votes data product to test vote tracking
     votes = Votes(governor_spec={'name': 'compound'})


### PR DESCRIPTION
We initially thought there was already some already existing object from the `Delegations` data product that we could reuse for this.

This initial thought was wrong and we didn't have something that would do this, at least not in a super inefficient way.

Created a `delegator_delegate` object to handle this