### PR TITLE
ENG-1697-recursive-logs

### DIFF
--- a/app/clients_httpjson.py
+++ b/app/clients_httpjson.py
@@ -264,7 +264,7 @@ class JsonRpcHistHttpClient(SubscriptionPlannerMixin):
             to_block = min(from_block + step - 1, end_block)  # Ensure we don't exceed the end_block
 
             for topic_chunk in topics:
-                chunk_logs = self.get_logs_unsafe(w3, contract_address, topic_chunk, from_block, to_block)
+                chunk_logs = self.get_logs_by_block_range(w3, contract_address, topic_chunk, from_block, to_block)
                 logs.extend(chunk_logs)
             
             if len(logs):

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -134,7 +134,7 @@ def test_web_socket_response_serialization_2(scroll_token_abi, ws_payload, signa
 
 load_dotenv()
 DAO_NODE_ARCHIVE_NODE_HTTP = "https://opt-mainnet.g.alchemy.com/v2/"
-ALCHEMY_API_KEY = os.getenv('ALCHEMY_API_KEY')
+ALCHEMY_API_KEY = os.getenv('ALCHEMY_API_KEY','')
 ARCHIVE_NODE_HTTP_URL = DAO_NODE_ARCHIVE_NODE_HTTP + ALCHEMY_API_KEY
 
 mock_logs = [{x: f"Test Log {x}" for x in range(100)}]

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -234,17 +234,14 @@ def test_get_paginated_logs_block_range_over_2000(test_package):
     end_block = 135262530
 
 
-    block_count_span = resolve_block_count_span(10)
-
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
-        jrhhc.connect(),
-        test_package['gov_contract_address'],
-        hash_of_event_sig,
-        start_block,
-        end_block,
-        block_count_span,
-        test_package['vote_cast_abi'],
+        w3=jrhhc.connect(),
+        contract_address=test_package['gov_contract_address'],
+        topics=[hash_of_event_sig],
+        start_block=start_block,
+        end_block=end_block,
+        step=1,
     )
 
     print(f"Found {len(logs)} CastVote events")

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -266,13 +266,12 @@ def test_get_paginated_logs_are_in_chronological_order(test_package):
 
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
-        jrhhc.connect(),
-        test_package['gov_contract_address'],
-        hash_of_event_sig,
-        start_block,
-        end_block,
-        block_count_span,
-        test_package['vote_cast_abi'],
+        w3=jrhhc.connect(),
+        contract_address=test_package['gov_contract_address'],
+        topics=[hash_of_event_sig],
+        start_block=start_block,
+        end_block=end_block,
+        step=1,
     )
 
     curr_high_bn = start_block


### PR DESCRIPTION
I was able to drop in a replacement from `get_logs_unsafe` for `get_logs_by_block_range`. This seems to run fine and pass the tests but is considerbly slower than the previous implementation. This may be related to either the functional call happening two loops deep, but it may have to do with the simplification of the coroutines. 

I have also added `end_block` into `get_paginated_logs` for testability and added `step` defaulting to 4