### PR TITLE
New approach to Participation Rate

### DIFF
--- a/app/abcs.py
+++ b/app/abcs.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+from .utils import camel_to_snake
+
+class DataProduct(ABC):
+
+    @abstractmethod
+    def handle(self, event):
+        pass
+
+    @property
+    def name(self):
+        return camel_to_snake(self.__class__.__name__)
+
+class DataModel(ABC):
+
+    @property
+    def name(self):
+        return camel_to_snake(self.__class__.__name__)
+    

--- a/app/data_models.py
+++ b/app/data_models.py
@@ -1,0 +1,144 @@
+from collections import defaultdict
+from .abcs import DataModel
+
+class ParticipationRateModel(DataModel):
+    def __init__(self):
+        self.completed_participation_fractions = defaultdict(lambda : (0, 0))
+        self.future_participation_fractions = defaultdict(lambda : (0, 0))
+
+    def refresh_one_completed_participation_fractions(self, addr, proposals_dp, votes_dp, delegations_dp):
+        
+        self.completed_participation_fractions[addr] = 0, 0 
+
+        # This should be a loop of no more than 10...
+        for proposal_id, start_block, _ in proposals_dp.prst.recently_completed_and_counted_proposals:
+            # this is a bisect algo 
+            vp = delegations_dp.delegatee_vp_at_block(addr, start_block)
+
+            if vp > 0:
+                    
+                voted = votes_dp.participated[addr][proposal_id]
+                    
+                num, den = self.completed_participation_fractions[addr]
+                
+                if voted:
+                    num += 1
+                
+                den += 1
+                        
+                self.completed_participation_fractions[addr] = (num, den)
+
+    def refresh_all_completed_participation_fractions(self, proposals_dp, votes_dp, delegations_dp):
+        
+        new_fractions = defaultdict(lambda : (0, 0))
+        
+        # This should be a loop of no more than 10...
+        for proposal_id, start_block, _ in proposals_dp.prst.recently_completed_and_counted_proposals:
+
+            # this is a giant loop, but ~200K for Optimism...
+            for delegatee_addr in delegations_dp.delegatee_vp_history.keys():
+
+                # this is a bisect algo 
+                vp = delegations_dp.delegatee_vp_at_block(delegatee_addr, start_block)
+
+                if vp > 0:
+                        
+                    voted = votes_dp.participated[delegatee_addr][proposal_id]
+                        
+                    num, den = new_fractions[delegatee_addr]
+                        
+                    if voted:
+                        num += 1
+                        
+                    den += 1
+                        
+                    new_fractions[delegatee_addr] = (num, den)
+
+        self.completed_participation_fractions = new_fractions
+
+    def refresh_one_future_participation_fractions(self, delegatee_addr, proposals_dp, votes_dp, delegations_dp):
+        
+        self.future_participation_fractions[delegatee_addr] = 0, 0
+        
+        # This should be a loop of no more than 10...
+        for proposal_id, start_block, end_block in proposals_dp.prst.ending_in_future_proposals:
+            # this is a bisect algo 
+            vp = delegations_dp.delegatee_vp_at_block(delegatee_addr, start_block)
+
+            if vp > 0:
+                
+                voted = votes_dp.participated[delegatee_addr][proposal_id]
+                
+                num, den = self.future_participation_fractions[delegatee_addr]
+                
+                if voted:
+                    num += 1
+                    den += 1
+                
+                self.future_participation_fractions[delegatee_addr] = (num, den)
+    
+
+    def refresh_all_future_participation_fractions(self, proposals_dp, votes_dp, delegations_dp):
+        
+        new_fractions = defaultdict(lambda : (0, 0))
+        
+        # This should be a loop of no more than 10...
+        for proposal_id, start_block, end_block in proposals_dp.prst.ending_in_future_proposals:
+
+            # this is a giant loop, but ~200K for Optimism...
+            for delegatee_addr in delegations_dp.delegatee_vp_history.keys():
+
+                num, den = new_fractions[delegatee_addr]
+
+                # this is a bisect algo 
+                vp = delegations_dp.delegatee_vp_at_block(delegatee_addr, start_block)
+
+                if vp > 0:
+                        
+                    voted = votes_dp.participated[delegatee_addr][proposal_id]
+                    
+                    if voted:
+                        num += 1
+                        den += 1
+
+                new_fractions[delegatee_addr] = (num, den)
+                                
+        self.future_participation_fractions = new_fractions
+
+
+    def refresh_if_necessary(self, proposal_dp, votes_dp, delegations_dp):
+        print(f"{proposal_dp.prst.flag_recently_completed_and_counted_has_changed=}")
+        print(f"{proposal_dp.prst.flag_ending_in_future_proposals_has_changed=}")
+
+        if proposal_dp.prst.flag_recently_completed_and_counted_has_changed:
+            self.refresh_all_completed_participation_fractions(proposal_dp, votes_dp, delegations_dp)
+            proposal_dp.prst.flag_recently_completed_and_counted_has_changed = False
+        
+        if proposal_dp.prst.flag_ending_in_future_proposals_has_changed:
+            self.refresh_all_future_participation_fractions(proposal_dp, votes_dp, delegations_dp)
+            proposal_dp.prst.flag_ending_in_future_proposals_has_changed = False
+
+    def get_rate(self, delegatee_addr):
+        
+        cnum, cden = self.completed_participation_fractions[delegatee_addr]
+        fnum, fden = self.future_participation_fractions[delegatee_addr]
+
+        den = cden + fden
+
+        if den == 0:
+            return 0.0
+        
+        num = cnum + fnum
+
+        return num / den
+    
+    def get_fraction(self, delegatee_addr):
+        
+        cnum, cden = self.completed_participation_fractions[delegatee_addr]
+        fnum, fden = self.future_participation_fractions[delegatee_addr]
+
+        return (cnum + fnum), (cden + fden)
+
+    def rates(self):
+        for addr in self.completed_participation_fractions.keys():
+            yield addr, self.get_rate(addr)

--- a/app/data_models.py
+++ b/app/data_models.py
@@ -6,28 +6,6 @@ class ParticipationRateModel(DataModel):
         self.completed_participation_fractions = defaultdict(lambda : (0, 0))
         self.future_participation_fractions = defaultdict(int)
 
-    def refresh_one_completed_participation_fractions(self, addr, proposals_dp, votes_dp, delegations_dp):
-        
-        self.completed_participation_fractions[addr] = 0, 0 
-
-        # This should be a loop of no more than 10...
-        for proposal_id, start_block, _ in proposals_dp.prst.recently_completed_and_counted_proposals:
-            # this is a bisect algo 
-            vp = delegations_dp.delegatee_vp_at_block(addr, start_block)
-
-            if vp > 0:
-                    
-                voted = votes_dp.participated[addr][proposal_id]
-                    
-                num, den = self.completed_participation_fractions[addr]
-                
-                if voted:
-                    num += 1
-                
-                den += 1
-                        
-                self.completed_participation_fractions[addr] = (num, den)
-
     def refresh_all_completed_participation_fractions(self, proposals_dp, votes_dp, delegations_dp):
         
         new_fractions = defaultdict(lambda : (0, 0))
@@ -55,27 +33,7 @@ class ParticipationRateModel(DataModel):
                     new_fractions[delegatee_addr] = (num, den)
 
         self.completed_participation_fractions = new_fractions
-
-    def refresh_one_future_participation_fractions(self, delegatee_addr, proposals_dp, votes_dp, delegations_dp):
-        
-        num = 0
-        
-        # This should be a loop of no more than 10...
-        for proposal_id, start_block, end_block in proposals_dp.prst.ending_in_future_proposals:
-            # this is a bisect algo 
-            vp = delegations_dp.delegatee_vp_at_block(delegatee_addr, start_block)
-
-            if vp > 0:
-                
-                voted = votes_dp.participated[delegatee_addr][proposal_id]
-                
-                num = self.future_participation_fractions[delegatee_addr]
-                
-                if voted:
-                    num += 1
-                
-        self.future_participation_fractions[delegatee_addr] = num
-    
+   
 
     def refresh_all_future_participation_fractions(self, proposals_dp, votes_dp, delegations_dp):
         

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -5,7 +5,7 @@ os.environ['AGORA_CONFIG_FILE'] = 'tests/test_config.yaml'
 from unittest.mock import Mock
 from sanic import Sanic
 from sanic.response import json
-from app.server import proposals_handler, proposal_types_handler, delegates_handler, delegate_handler, ParticipationModel
+from app.server import proposals_handler, proposal_types_handler, delegates_handler, delegate_handler
 from app.data_products import Proposals, Votes, Delegations, ProposalTypes, Balances
 from app.clients_csv import CSVClient
 from app.signatures import *
@@ -320,6 +320,10 @@ async def test_delegate_endpoint(app, test_client, scroll_token_abi):
 
         def completed(self, head=10):
             return []
+
+    class MockParticipationRateModel:
+        def get_fraction(self, addr):
+            return 0, 0
     
     class MockVotes:
         def __init__(self):
@@ -339,6 +343,7 @@ async def test_delegate_endpoint(app, test_client, scroll_token_abi):
 
     app.ctx.proposals = MockProposals()
     app.ctx.votes = MockVotes()
+    app.ctx.participation_rate_model = MockParticipationRateModel()
     
     req, resp = await test_client.get('/v1/delegate/0xabcdef1234567890123456789012345678901234')
     assert resp.status == 200


### PR DESCRIPTION
This PR:

* Improves speed of serving PR by roughly ~2x (saving ~50% server time for 1000 delegates)
* Fixes bug related to VP-snapshot at time of proposal start (was not properly handled before)
* Fixes bug related to excluding finished but not queued or executed proposals (was not properly handled before)
* Bonus: We could sort by participation rate now if we wanted to.  (was not possible before due to just-in-time nature of the calc and being too slow).

... it does this by changing the algorithm + data structure.

We now maintain the participation rate using:

1. Two lists of proposal IDs:

* "Up to 10 Completed Proposals" - the proposals that have definitively ended most recently by either, excluding cancelled and `optimistic` proposals.  aka "the 10 [proposals]".
* "Future Proposals" - proposals that will end in the future according to their ending block. aka "the future [proposals]".

...updating the completed ones with log events, and popping the future proposals by block number in a light-check way.

2. Two dictionaries of the form:

```
completed = { addr : (# of proposals voted upon in the 10 list, # of proposal in the 10 list }
future = { addr : # of proposals voted upon in the future proposals }
```

...then we update either dictionary if the universe changes, only if that one part of the universe changes.  For Optimism, this is a ~3 second CPU-hogging calc immediately upon startup, and then anytime a proposal event triggers a refresh - so, super rare.  It's 1.4 seconds for Scroll.  These were measured locally.

To test, I sorted by VP, compared against production for 2000 addresses.  985 matched.  Of the ones that didn't match, I visually inspected a few of the non-matches, and they looked better.

I also compared the `'Server-Timing'` to see 74ms with the new way, and 156ms with the old way.


