### PR TITLE
ENG-1697-recursive-logs

### DIFF
--- a/app/clients_httpjson.py
+++ b/app/clients_httpjson.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from collections import defaultdict
 
 from web3 import Web3
+from web3.exceptions import Web3RPCError
 from web3.middleware import ExtraDataToPOAMiddleware
 from sanic.log import logger as logr
 
@@ -310,9 +311,9 @@ It is unlikely that this function will ever be called directly, and is instead c
             logs = w3.eth.get_logs(event_filter)
         except Exception as e:
             # catch and attempt to recover block limitation ranges
-            if hasattr(e, 'response'):
-                response_json = json.loads(e.response.text)
-                api_error_code = response_json.get("error", {}).get("code")
+            if isinstance(e, Web3RPCError):
+                error_dict = eval(str(e.args[0]))  # Convert string representation to dict
+                api_error_code = error_dict['code']
                 if api_error_code == -32600 or api_error_code == -32602:
                     # add one to recursion depth
                     new_recursion_depth = current_recursion_depth + 1
@@ -370,15 +371,15 @@ It is unlikely that this function will ever be called directly, and is instead c
             yield block
 
     def read_blocks(self, chain_id, after):
-        
+
         w3 = self.connect()
 
         latest_block = w3.eth.block_number
 
         chain_id = w3.eth.chain_id
 
-        step = resolve_block_count_span(chain_id) 
-        
+        step = resolve_block_count_span(chain_id)
+
         blocks = self.get_paginated_blocks(w3, chain_id, start_block=after, end_block=latest_block, step=step)
 
         for block in blocks:
@@ -403,8 +404,8 @@ It is unlikely that this function will ever be called directly, and is instead c
 
         new_signal = True
         for chain_id in self.event_subsription_meta.keys():
-            
-            step = resolve_block_count_span(chain_id) 
+
+            step = resolve_block_count_span(chain_id)
 
             for address in self.event_subsription_meta[chain_id].keys():
 
@@ -434,7 +435,7 @@ It is unlikely that this function will ever be called directly, and is instead c
 
                     all_logs.append((out, signature, new_signal))
 
-        all_logs.sort(key=lambda x: (x[0]['block_number'], x[0]['transaction_index'], x[0]['log_index']))   
+        all_logs.sort(key=lambda x: (x[0]['block_number'], x[0]['transaction_index'], x[0]['log_index']))
 
         for log in all_logs:
             yield log

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -140,45 +140,8 @@ ARCHIVE_NODE_HTTP_URL = DAO_NODE_ARCHIVE_NODE_HTTP + ALCHEMY_API_KEY
 mock_logs = [{x: f"Test Log {x}" for x in range(100)}]
 
 optimism_package = {
-    "gov_contract_address": "0xcDF27F107725988f2261Ce2256bDfCdE8B382B10",
-    "vote_cast_abi": {
-        "type": "event",
-        "name": "VoteCast",
-        "inputs": [
-            {
-                "name": "voter",
-                "type": "address",
-                "indexed": True,
-                "internalType": "address"
-            },
-            {
-                "name": "proposalId",
-                "type": "uint256",
-                "indexed": False,
-                "internalType": "uint256"
-            },
-            {
-                "name": "support",
-                "type": "uint8",
-                "indexed": False,
-                "internalType": "uint8"
-            },
-            {
-                "name": "weight",
-                "type": "uint256",
-                "indexed": False,
-                "internalType": "uint256"
-            },
-            {
-                "name": "reason",
-                "type": "string",
-                "indexed": False,
-                "internalType": "string"
-            }
-        ],
-        "anonymous": False
-    },
-    "event_signature": "VoteCast(address,uint256,uint8,uint256,string)",
+    "contract_address": "0x4200000000000000000000000000000000000042",
+    "event_signature": "Transfer(address,address,uint256)",
 }
 
 @pytest.mark.skipif(
@@ -202,7 +165,7 @@ def test_get_paginated_logs(test_package):
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
         w3 = jrhhc.connect(),
-        contract_address = test_package['gov_contract_address'],
+        contract_address = test_package['contract_address'],
         topics = [hash_of_event_sig],
         start_block=start_block,
         end_block=end_block,
@@ -211,7 +174,7 @@ def test_get_paginated_logs(test_package):
     # Just grab block numbers
     # Could look at token contract and do token transfer events
 
-    print(f"Found {len(logs)} CastVote events")
+    print(f"Found {len(logs)} events")
     assert len(logs) == 2
     # Check first and second block numbers for logs are as expected
     assert logs[0]['blockNumber']== 135262518
@@ -237,14 +200,14 @@ def test_get_paginated_logs_block_range_over_2000(test_package):
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
         w3=jrhhc.connect(),
-        contract_address=test_package['gov_contract_address'],
+        contract_address=test_package['contract_address'],
         topics=[hash_of_event_sig],
         start_block=start_block,
         end_block=end_block,
         step=1,
     )
 
-    print(f"Found {len(logs)} CastVote events")
+    print(f"Found {len(logs)} events")
     assert len(logs) == 87
 
 @pytest.mark.skipif(

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -159,7 +159,7 @@ def test_get_paginated_logs(test_package):
 
     # Define block range for Optimism token events
     start_block = 135262515
-    end_block = 135262530
+    end_block = 135262516
 
 
     # Query transfer logs from Optimism token contract
@@ -169,23 +169,23 @@ def test_get_paginated_logs(test_package):
         topics = [hash_of_event_sig],
         start_block=start_block,
         end_block=end_block,
-        step=1,
+        step=2000,
     )
     # Just grab block numbers
     # Could look at token contract and do token transfer events
 
     print(f"Found {len(logs)} events")
-    assert len(logs) == 2
+    assert len(logs) == 8
     # Check first and second block numbers for logs are as expected
-    assert logs[0]['blockNumber']== 135262518
-    assert logs[1]['blockNumber'] == 135262521
+    assert logs[0]['blockNumber']== 135262515
+    assert logs[-1]['blockNumber'] == 135262516
 
 @pytest.mark.skipif(
     not ALCHEMY_API_KEY,
     reason="Skipping because ALCHEMY_API_KEY is not set"
 )
 @pytest.mark.parametrize("test_package", [optimism_package])
-def test_get_paginated_logs_block_range_over_2000(test_package):
+def test_get_paginated_logs_recursive_call(test_package):
     print("\n")
     jrhhc = JsonRpcHistHttpClient(ARCHIVE_NODE_HTTP_URL)
 
@@ -193,8 +193,9 @@ def test_get_paginated_logs_block_range_over_2000(test_package):
     hash_of_event_sig = '0x' + keccak(test_package['event_signature'].encode()).hex()
 
     # Define block range for Optimism token events
-    start_block = 135252530
-    end_block = 135262530
+    # This range includes one recursive call
+    start_block = 135100000
+    end_block = 135120000
 
 
     # Query transfer logs from Optimism token contract
@@ -204,11 +205,11 @@ def test_get_paginated_logs_block_range_over_2000(test_package):
         topics=[hash_of_event_sig],
         start_block=start_block,
         end_block=end_block,
-        step=1,
+        step=20000,
     )
 
     print(f"Found {len(logs)} events")
-    assert len(logs) == 87
+    assert len(logs) == 38775
 
 @pytest.mark.skipif(
     not ALCHEMY_API_KEY,
@@ -230,11 +231,11 @@ def test_get_paginated_logs_are_in_chronological_order(test_package):
     # Query transfer logs from Optimism token contract
     logs = jrhhc.get_paginated_logs(
         w3=jrhhc.connect(),
-        contract_address=test_package['gov_contract_address'],
+        contract_address=test_package['contract_address'],
         topics=[hash_of_event_sig],
         start_block=start_block,
         end_block=end_block,
-        step=1,
+        step=20000,
     )
 
     curr_high_bn = start_block


### PR DESCRIPTION
Updated dao-node test.

This had two issues resolved.
1. We are now using the Web3RPCError type directly rather than inferring its json string representation. 
2. Our test was using a step size of two, which split our get_eth_log calls into block ranges of 1. I now have it set at 20k so we can trigger the recursive call, and picked a suitable block range that triggers this.