### PR TITLE
Reduce Alchemy WS usage via single client and batched subscriptions

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -1516,7 +1516,7 @@ if INCLUDE_NON_IVOTES_VP:
 ################################################################################
 
 NUM_ARCHIVE_CLIENTS = int(os.getenv('NUM_ARCHIVE_CLIENTS', 2))
-NUM_REALTIME_CLIENTS = int(os.getenv('NUM_REALTIME_CLIENTS', 2))
+NUM_REALTIME_CLIENTS = int(os.getenv('NUM_REALTIME_CLIENTS', 1))
 NUM_POLLING_CLIENTS = int(os.getenv('NUM_POLLING_CLIENTS', 1))
 
 @app.before_server_start(priority=0)


### PR DESCRIPTION
 * Default NUM_REALTIME_CLIENTS to 1 to avoid redundant WebSocket connections
 * Batch event topics per contract into a single eth_subscribe logs subscription
 * Derive topic from incoming events when dispatching, preserving existing casting logic